### PR TITLE
Create ipk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(asteroid-helloworld
 	VERSION 0.0.1
@@ -20,3 +20,14 @@ add_subdirectory(src)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-helloworld)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+set(CPACK_GENERATOR "DEB")
+string(TOLOWER "${CMAKE_PROJECT_NAME}" lcproject_name)
+set(CPACK_DEBIAN_FILE_NAME "${lcproject_name}-${CMAKE_PROJECT_VERSION}.ipk")
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE armv7vehf-neon)
+if (NOT CPACK_PACKAGE_CONTACT) 
+    set(CPACK_PACKAGE_CONTACT bogus@example.org)
+    message(WARNING "No package contact specified: using ${CPACK_PACKAGE_CONTACT}")
+endif()
+include(CPack)

--- a/asteroid-helloworld.desktop
+++ b/asteroid-helloworld.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Type=Application
-Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-helloworld
-Icon=ios-pulse-outline
-X-Asteroid-Center-Color=#b04d1c
-X-Asteroid-Outer-Color=#421c0a
-Name=Hello World App


### PR DESCRIPTION
This adds code to the example project to support the `package` target and to generate an `.ipk` file that can then be conveniently installed on the watch.