### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ include(AsteroidTranslations)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-helloworld.in
+	${CMAKE_BINARY_DIR}/asteroid-helloworld
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-helloworld
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-helloworld)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/asteroid-helloworld.desktop.template
+++ b/asteroid-helloworld.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-helloworld
+Exec=asteroid-helloworld
 Icon=ios-pulse-outline
 X-Asteroid-Center-Color=#b04d1c
 X-Asteroid-Outer-Color=#421c0a

--- a/asteroid-helloworld.in
+++ b/asteroid-helloworld.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-helloworld.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-helloworld main.cpp resources.qrc)
-set_target_properties(asteroid-helloworld PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-helloworld PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-helloworld PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-helloworld
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker