### PR TITLE
Switch invoker to use booster-qt5

### DIFF
--- a/asteroid-helloworld.in
+++ b/asteroid-helloworld.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-helloworld.so
+exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-helloworld.so


### PR DESCRIPTION
booster-qtcomponents-qt5 has been deprecated upstream and the application launches fine with just booster-qt5 as well

Replaces #7, not sure what happened there.