### PR TITLE
Override cmake default for Debian build host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ generate_desktop(${CMAKE_SOURCE_DIR} asteroid-helloworld)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
+set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL "Install .so files with execute permission.")
 set(CPACK_GENERATOR "DEB")
 string(TOLOWER "${CMAKE_PROJECT_NAME}" lcproject_name)
 set(CPACK_DEBIAN_FILE_NAME "${lcproject_name}-${CMAKE_PROJECT_VERSION}.ipk")


### PR DESCRIPTION
cmake by defaults from AtseroidOS SDK

sysroots/x86_64-oesdk-linux/usr/share/cmake-3.22/Modules/Platform/Linux.cmake

prevents .so libraries to be installed with execute permission when packaged on Debian host systems. This patch overrides that default.