### PR TITLE
Make the template easier to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,14 @@ include(AsteroidTranslations)
 
 add_subdirectory(src)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-helloworld.in
-	${CMAKE_BINARY_DIR}/asteroid-helloworld
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/runscript.in
+	${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}
 	@ONLY)
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-helloworld
+install(PROGRAMS ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}
 	DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-generate_desktop(${CMAKE_SOURCE_DIR} asteroid-helloworld)
+generate_desktop(${CMAKE_SOURCE_DIR} ${CMAKE_PROJECT_NAME})
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 A simple hello world app for [AsteroidOS](http://asteroidos.org/)
 
 See https://wiki.asteroidos.org/index.php/Creating_an_Asteroid_app for instruction on how to build and run it.
+
+If you have used the Hello World App as a template and wish to use it as the basis for your own AsteroidOS application here are the steps:
+
+ 1. Decide on a name for your project, (we use `myproject-name` as an example here)
+ 2. Change the project name in `CMakeLists.txt` from `asteroid-helloworld` to your name (e.g. `myproject-name`)
+ 3. Rename the `i18n/asteroid-helloworld.desktop.h` file to user your project name (e.g. `i18n/myproject-name.desktop.h`)
+ 4. Rename the `asteroid-helloworld.desktop.template` file to use your project name (e.g. `myproject-name.desktop.template`)
+ 5. Edit the newly renamed `destkop.template` file from the previous step and change the `Exec=` line to your project name
+ 6. Optionally, but highly recommended, change the `Icon`, `X-Asteroid-Center-Color` and `X-Asteroid-Outer-Color` values in that same file
+ 7. Alter the functionality to suit
+
+
+Note that for steps 3 and 4, use `git mv` to rename the files so that your repository will reflect these changes.

--- a/asteroid-helloworld.in
+++ b/asteroid-helloworld.in
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/libasteroid-helloworld.so

--- a/runscript.in
+++ b/runscript.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/lib@CMAKE_PROJECT_NAME@.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_library(asteroid-helloworld main.cpp resources.qrc)
+add_library(${CMAKE_PROJECT_NAME} main.cpp resources.qrc)
 
-target_link_libraries(asteroid-helloworld PUBLIC
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
 	AsteroidApp)
 
-install(TARGETS asteroid-helloworld
+install(TARGETS ${CMAKE_PROJECT_NAME}
 	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
This modifies the project to make it easier to use as a template for a new project by using CMAKE_PROJECT_NAME where practical and by adding instructions to the README.md file to describe how to use the template in this way.