### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_library(${CMAKE_PROJECT_NAME} main.cpp resources.qrc)
+add_library(${CMAKE_PROJECT_NAME} main.cpp)
+
+asteroid_app_qml_module(${CMAKE_PROJECT_NAME}
+	main.qml
+)
 
 target_link_libraries(
 	${CMAKE_PROJECT_NAME}

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/">
-        <file>main.qml</file>
-    </qresource>
-</RCC>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.